### PR TITLE
[FEAT] Socket.IO 연결 및 게임방 채팅영역 소켓 연동 #1

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,39 +1,118 @@
 import { Server } from 'socket.io';
 
 // Socket.io 서버 생성 및 CORS 설정
-const io = new Server(3000, {
+const io = new Server(4000, {
   cors: {
     origin: '*', // 모든 도메인 허용, 추후 vercel 도메인으로 수정
   },
 });
 
-// 사용자 연결 처리
+const gameRooms = {};
+
+// 유저 소켓 연결
 io.on('connection', (socket) => {
   console.log('A user connected:', socket.id);
 
-  // 방 입장 이벤트
-  socket.on('enter_room', (nickname, roomName, done) => {
-    socket.join(roomName);
-    socket['nickname'] = nickname;
-    console.log(`${nickname} joined room: ${roomName}`);
-    done();
-    io.to(roomName).emit('welcome', nickname);
+  // 게임방 만들기
+  socket.on('createRoom', (roomId, userInfo, roomInfo) => {
+    const { nickname, clickedAvatarIndex, isVideoOn, isFlipped } = userInfo;
+    const { rounds, topic, isItemsEnabled } = roomInfo;
+
+    socket.join(roomId);
+    console.log(`User ${nickname} (ID: ${socket.id}) created room ${roomId}`);
+
+    gameRooms[roomId] = {
+      host: socket.id,
+      gameStatus: 'waiting',
+      currentDrawer: null,
+      currentWord: null,
+      totalWords: [], // 단어카드 DB 작업 이후 주제별 120개의 단어로 초기세팅 (topic 사용)
+      selectedWords: [],
+      isWordSelected: false,
+      selectionDeadline: null,
+      maxRound: rounds,
+      round: 0,
+      turn: 0,
+      turnDeadline: null,
+      correctAnswerCount: 0,
+      isItemsEnabled,
+      items: {
+        ToxicCover: { user: null, status: false },
+        GrowingBomb: { user: null, status: false },
+        PhantomReverse: { user: null, status: false },
+        LaundryFlip: { user: null, status: false },
+        TimeCutter: { user: null, status: false },
+      },
+      order: [],
+      participants: {},
+    };
+
+    const gameState = gameRooms[roomId];
+
+    gameState.order.push(socket.id);
+    gameState.participants[socket.id] = {
+      nickname,
+      score: 0,
+      clickedAvatarIndex,
+      isVideoOn,
+      isFlipped,
+    };
+
+    io.to(roomId).emit('gameStateUpdate', gameState);
   });
 
-  // 메시지 전송 이벤트
-  socket.on('new_message', (msg, roomName, done) => {
-    console.log(`Message from ${socket.nickname} in room ${roomName}: ${msg}`);
-    socket.to(roomName).emit('new_message', `${socket.nickname}: ${msg}`);
-    done();
+  // 게임방 입장
+  socket.on('joinRoom', (roomId, userInfo) => {
+    const { nickname, clickedAvatarIndex, isVideoOn, isFlipped } = userInfo;
+
+    socket.join(roomId);
+    console.log(`User ${nickname} (ID: ${socket.id}) joined room ${roomId}`);
+
+    const gameState = gameRooms[roomId];
+
+    gameState.order.push(socket.id);
+    gameState.participants[socket.id] = {
+      nickname,
+      score: 0,
+      clickedAvatarIndex,
+      isVideoOn,
+      isFlipped,
+    };
+
+    io.to(roomId).emit('gameStateUpdate', gameState);
+
+    socket.to(roomId).emit('userJoined', nickname);
   });
 
-  // 사용자 연결 해제 처리
+  // 채팅 메시지 전송
+  socket.on('sendMessage', (roomId, messageData) => {
+    const { nickname, message } = messageData;
+    console.log(`${nickname} sent message in room ${roomId}: ${message}`);
+
+    io.to(roomId).emit('newMessage', { nickname, message });
+  });
+
+  // 게임방 퇴장
   socket.on('disconnecting', () => {
-    socket.rooms.forEach((room) => io.to(room).emit('bye', socket.nickname));
-  });
+    console.log(`User ${socket.id} disconnected`);
 
-  socket.on('disconnect', () => {
-    console.log('A user disconnected:', socket.id);
+    socket.rooms.forEach((roomId) => {
+      const gameState = gameRooms[roomId];
+
+      if (gameState) {
+        const nickname = gameState.participants[socket.id].nickname;
+        delete gameState.participants[socket.id];
+        gameState.order = gameState.order.filter((id) => id !== socket.id);
+
+        socket.to(roomId).emit('userLeft', nickname);
+
+        if (gameState.order.length === 0) {
+          delete gameRooms[roomId];
+        } else {
+          socket.to(roomId).emit('gameStateUpdate', gameState);
+        }
+      }
+    });
   });
 
   // 에러 핸들링
@@ -43,4 +122,4 @@ io.on('connection', (socket) => {
   });
 });
 
-console.log('Socket.IO server running on port 3000 🚀');
+console.log('Socket.IO server running on port 4000 🚀');


### PR DESCRIPTION
### 📝 관련 이슈
closed #1 

- 관련 클라이언트 레포지토리 PR: [[FEAT] 채팅영역 작업 및 대기실 페이지 Socket.IO 연동](https://github.com/DoodlePlay/Frontend/pull/25)

### ✨ 반영 브랜치
- FROM: `1-feat/room-and-chat`
- TO: `master`

### ✅ PR 내용
- [x] 게임상태 정보 소켓 저장 및 클라이언트 전역 관리 동기화
> - roomId가 Key이고 gameStatus가 값인 객체 gameRooms 저장
> - `zustand`를 사용해 클라이언트 측에서 `socket.io` 연결과 게임 상태를 동기화
```
interface Participant {
  nickname: string;
  score: number;
  clickedAvatarIndex: number;
  isVideoOn: boolean;
  isFlipped: boolean;
}

interface GameState {
  host: string;
  gameStatus: 'waiting' | 'choosing' | 'drawing';
  currentDrawer: string | null;
  currentWord: string | null;
  totalWords: string[];
  selectedWords: string[];
  isWordSelected: boolean;
  selectionDeadline: number | null;
  maxRound: number;
  round: number;
  turn: number;
  turnDeadline: number | null;
  correctAnswerCount: number;
  isItemsEnabled: boolean;
  items: Record<string, { user: string | null; status: boolean }>;
  order: string[];
  participants: Record<string, Participant>;
}
```

- [x] 소켓 연동 및 기능별 이벤트 추가
  > - `createRoom`, `joinRoom`: 게임방 입장 및 소켓 연결
  > - `gameStateUpdate`: 소켓 정보와 전역 상태 관리 값을 동기화하여 컴포넌트 렌더링
  > - `userJoined`, `userLeft`: 게임방 입장 및 퇴장 시 채팅영역 시스템 메세지 전송
  > - `sendMessage`, `newMessage`: 게임방 채팅영역 메세지 송수신

### 🌐 테스트 배포
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
> - 테스트 배포 주소: https://sm-doodle-play.netlify.app/
> - 테스트 환경 (OS): MacOS
> - 테스트 환경 (Browser): Chrome / Safari / Firefox / Edge

### 📸 스크린샷
![게임방.gif](https://github.com/user-attachments/assets/821baeaa-a75e-4128-b03a-e85b25b9e971)

### 📌 ETC
- 로컬 클라이언트(`3000`포트)와 로컬 서버(`4000`포트)에서 테스트했습니다. 클라이언트 레포지토리 PR merge 된 후에 테스트 배포 주소에서 채팅 기능 사용할 수 있습니다.
