### PR TITLE
[FEAT] 아이템 사용 소켓 작업 #8

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -58,6 +58,7 @@ io.on('connection', (socket) => {
       turnDeadline: null,
       correctAnswerCount: 0,
       isItemsEnabled,
+      activeItem: null,
       items: {
         ToxicCover: { user: null, status: false },
         GrowingBomb: { user: null, status: false },
@@ -104,6 +105,22 @@ io.on('connection', (socket) => {
     io.to(roomId).emit('gameStateUpdate', gameState);
 
     socket.to(roomId).emit('userJoined', nickname);
+  });
+
+  // 그림 데이터 수신 및 브로드캐스트
+  socket.on('drawing', (roomId, drawingData) => {
+    socket.to(roomId).emit('drawingData', drawingData); // 같은 방에 있는 다른 사용자에게 브로드캐스트
+  });
+
+  // 아이템 사용
+  socket.on('itemUsed', (roomId, itemId) => {
+    const gameState = gameRooms[roomId];
+
+    gameState.activeItem = itemId;
+    gameState.items[itemId].user = socket.id;
+    gameState.items[itemId].status = true;
+
+    io.to(roomId).emit('itemUsedUpdate', gameState);
   });
 
   // 채팅 메시지 전송
@@ -164,11 +181,6 @@ io.on('connection', (socket) => {
   socket.on('error', (error) => {
     console.error('Socket encountered error:', error);
     socket.disconnect();
-  });
-
-  // 그림 데이터 수신 및 브로드캐스트
-  socket.on('drawing', (roomId, drawingData) => {
-    socket.to(roomId).emit('drawingData', drawingData); // 같은 방에 있는 다른 사용자에게 브로드캐스트
   });
 });
 


### PR DESCRIPTION
### 📝 관련 이슈
closed #8 

### ✨ 반영 브랜치
- FROM: `8-feat/item-socket`
- TO: `master`

### ✅ PR 내용
- [x] `gameState`에 `activeItem` 프로퍼티 추가
  > - Description: 아이템 효과 발생시점을 클라이언트에 전달할 값입니다. 클라이언트에서 유저가 아이템을 사용하면 소켓이벤트가 서버로 전송되고 서버에서는 `activeItem`에 아이템 id를 담아 클라이언트로 다시 소켓이벤트를 전송해서 동일 게임방에 있는 모든 유저가 동시에 아이템 효과가 발생하도록 합니다.

- [x] 아이템 소켓 이벤트 연동
  > - Description: 클라이언트로부터 아이템 사용 이벤트를 받아서 `gameState`의 `Items`와 `activeItem`에 반영시키고 다시 클라이언트로 이벤트 전송해서 동기화시킵니다.
  ```
  // 아이템 사용
  socket.on('itemUsed', (roomId, itemId) => {
    const gameState = gameRooms[roomId];

    gameState.activeItem = itemId;
    gameState.items[itemId].user = socket.id;
    gameState.items[itemId].status = true;

    io.to(roomId).emit('itemUsedUpdate', gameState);
  });
  ```

### 🌐 테스트 배포
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
  > - 테스트 배포 주소: https://sm.doodleplay.xyz/
  > - 테스트 환경 (OS): MacOS
  > - 테스트 환경 (Browser): Chrome / Safari / Firefox / Edge

### 📌 ETC
- 관련 클라이언트 레포지토리: [[FEAT] 아이템 사용 소켓 작업 #35](https://github.com/DoodlePlay/Frontend/pull/37)
- 서버 레포지토리 merge 전에는 테스트 배포 채널에서 아이템 관련 확인이 불가능합니다!
