### PR TITLE
[FEAT] 게임 진행 우선 소켓 작업 #7

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -122,6 +122,7 @@ io.on('connection', (socket) => {
     }
 
     gameState.gameStatus = 'choosing';
+    gameState.currentDrawer = gameState.host; // TEST
     gameState.round = 1;
     gameState.turn = 1;
     gameState.selectedWords = gameState.totalWords.slice(0, 2);

--- a/src/server.js
+++ b/src/server.js
@@ -112,6 +112,25 @@ io.on('connection', (socket) => {
     socket.to(roomId).emit('drawingData', drawingData); // 같은 방에 있는 다른 사용자에게 브로드캐스트
   });
 
+  // 게임 시작
+  socket.on('startGame', (roomId) => {
+    const gameState = gameRooms[roomId];
+
+    if (!gameState) {
+      console.error(`Room ${roomId} not found`);
+      return;
+    }
+
+    gameState.gameStatus = 'choosing';
+    gameState.round = 1;
+    gameState.turn = 1;
+    gameState.selectedWords = gameState.totalWords.slice(0, 2);
+
+    gameState.selectionDeadline = Date.now() + 5000;
+
+    io.to(roomId).emit('gameStateUpdate', gameState);
+  });
+
   // 아이템 사용
   socket.on('itemUsed', (roomId, itemId) => {
     const gameState = gameRooms[roomId];

--- a/src/server.js
+++ b/src/server.js
@@ -113,7 +113,7 @@ io.on('connection', (socket) => {
   });
 
   // 게임 시작
-  socket.on('startGame', (roomId) => {
+  socket.on('startGame', async (roomId) => {
     const gameState = gameRooms[roomId];
 
     if (!gameState) {
@@ -125,8 +125,24 @@ io.on('connection', (socket) => {
     gameState.round = 1;
     gameState.turn = 1;
     gameState.selectedWords = gameState.totalWords.slice(0, 2);
-
     gameState.selectionDeadline = Date.now() + 5000;
+
+    io.to(roomId).emit('gameStateUpdate', gameState);
+  });
+
+  // 단어 선택
+  socket.on('chooseWord', (roomId, chooseWord) => {
+    const gameState = gameRooms[roomId];
+
+    if (!gameState) {
+      console.error(`Room ${roomId} not found`);
+      return;
+    }
+
+    gameState.currentWord = chooseWord;
+    gameState.isWordSelected = true;
+    gameState.gameStatus = 'drawing';
+    // gameState.turnDeadline = Date.now() + 90000;
 
     io.to(roomId).emit('gameStateUpdate', gameState);
   });

--- a/src/server.js
+++ b/src/server.js
@@ -113,7 +113,7 @@ io.on('connection', (socket) => {
   });
 
   // 게임 시작
-  socket.on('startGame', async (roomId) => {
+  socket.on('startGame', (roomId) => {
     const gameState = gameRooms[roomId];
 
     if (!gameState) {


### PR DESCRIPTION
### 📝 관련 이슈
closed #7 

### ✨ 반영 브랜치
<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->
- FROM: `7-feat/game-flow-socket-implementation`
- TO: `master`

### ✅ PR 내용
- [x] 게임 시작 로직 추가 (onStartGame)
  > - AS-IS : `onStartGame`에서 단순히 콘솔에 'Game started' 메시지를 출력
  > - TO-BE : `onStartGame` 함수가 `socket`과 `roomId`를 이용해 서버에 `startGame` 이벤트를 보냄. 서버에서 게임 상태를 업데이트하고, 클라이언트 측에서는 `updateGameStatus` 함수를 사용해 게임 상태를 'playing'으로 변경(DB gameroom status 업데이트)
  > - Description : 게임 시작에 대한 클라이언트와 서버 간의 동기화를 구현하여 실제 게임이 시작될 수 있도록 처리. 게임 시작과 관련된 데이터 동기화

- [x] 게임 시작 로직 후 choosing 상태 로직 selectedWords와 currentDrawer 초기화
  > - AS-IS : 없음
  > - TO-BE : 서버 측 `startGame` 로직에서 `currentDrawer`를 `host`로 설정하고, `selectedWords`를 단어 리스트 중에서 두 개 선택해 `currentWord` 설정
  > - Description : 단어 선택으로 currentWord가 생성되고, 해당 선택화면은 currentDrawer만 확인 및 선택 가능
현재 currentDrawer만 toolBar 및 그림을 그리도록 구현해야 하지만 그림 데이터를 그릴 수 있는 권한 부여 부분은 구현되어 있지 않음. 쉽게 해결 되지 않아서 디테일 작업 시 함께 작업 예정.

### 🌐 테스트 배포
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
  > - 테스트 배포 주소: https://jm-doodleplay.netlify.app/game
  > - 테스트 환경 (OS): Windows
  > - 테스트 환경 (Browser): Chrome / Firefox / Edge

### 📌 ETC
<!-- 레퍼런스, 참고할 사항, 질문 사항이 있다면 적어주세요 (Optional) -->
merge 후 확인 가능합니다.