### PR TITLE
[FEAT] 게임 진행 소켓 작업 #12

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -341,12 +341,17 @@ io.on('connection', (socket) => {
           }
         }
 
+        // TODO : 현재 그림을 그리는 사람이 나가게 되면 어떻게 해야할지
+        if (gameState.currentDrawer === socket.id) {
+          gameState.turnDeadline = Date.now();
+        }
+
         // 남은 플레이어 수가 3명 미만이면 게임을 대기 상태로 전환
         const playerCount = Object.keys(gameState.participants).length;
         if (playerCount < 3) {
           gameState.gameStatus = 'waiting';
-          gameState.turnDeadline = null;
           gameState.selectionDeadline = null;
+          gameState.turnDeadline = null;
 
           // Firebase의 gameStatus를 업데이트
           try {

--- a/src/server.js
+++ b/src/server.js
@@ -352,6 +352,7 @@ io.on('connection', (socket) => {
           gameState.gameStatus = 'waiting';
           gameState.selectionDeadline = null;
           gameState.turnDeadline = null;
+          gameState.round = 10;
 
           // Firebase의 gameStatus를 업데이트
           try {

--- a/src/server.js
+++ b/src/server.js
@@ -128,13 +128,10 @@ io.on('connection', (socket) => {
     gameState.selectedWords = gameState.totalWords.slice(0, 2);
     gameState.selectionDeadline = Date.now() + 5000;
 
-    // TODO : Firebase의 gameStatus를 'playing'으로 업데이트
+    // Firebase의 gameStatus를 'playing'으로 업데이트
     try {
       const roomRef = db.collection('GameRooms').doc(roomId);
       await roomRef.update({ gameStatus: 'playing' });
-      console.log(
-        `Firebase gameStatus updated to 'playing' for room ${roomId}`
-      );
     } catch (error) {
       console.error(
         `Failed to update gameStatus in Firebase for room ${roomId}:`,

--- a/src/server.js
+++ b/src/server.js
@@ -176,6 +176,7 @@ io.on('connection', (socket) => {
     );
     gameState.selectionDeadline = Date.now() + 5000;
     gameState.turnDeadline = null;
+    io.to(roomId).emit('clearCanvas');
     setTimeout(() => {
       if (
         !gameState.isWordSelected &&
@@ -358,6 +359,7 @@ io.on('connection', (socket) => {
           );
           gameState.selectionDeadline = Date.now() + 5000;
           gameState.turnDeadline = null;
+          io.to(roomId).emit('clearCanvas');
           setTimeout(() => {
             if (
               !gameState.isWordSelected &&

--- a/src/server.js
+++ b/src/server.js
@@ -113,7 +113,7 @@ io.on('connection', (socket) => {
   });
 
   // 게임 시작
-  socket.on('startGame', (roomId) => {
+  socket.on('startGame', async (roomId) => {
     const gameState = gameRooms[roomId];
 
     if (!gameState) {
@@ -127,6 +127,20 @@ io.on('connection', (socket) => {
     gameState.turn = 1;
     gameState.selectedWords = gameState.totalWords.slice(0, 2);
     gameState.selectionDeadline = Date.now() + 5000;
+
+    // TODO : Firebase의 gameStatus를 'playing'으로 업데이트
+    try {
+      const roomRef = db.collection('GameRooms').doc(roomId);
+      await roomRef.update({ gameStatus: 'playing' });
+      console.log(
+        `Firebase gameStatus updated to 'playing' for room ${roomId}`
+      );
+    } catch (error) {
+      console.error(
+        `Failed to update gameStatus in Firebase for room ${roomId}:`,
+        error
+      );
+    }
 
     io.to(roomId).emit('gameStateUpdate', gameState);
   });

--- a/src/server.js
+++ b/src/server.js
@@ -146,7 +146,14 @@ io.on('connection', (socket) => {
       gameState.gameStatus = 'waiting';
       gameState.selectionDeadline = null;
       gameState.turnDeadline = null;
-      gameState.totalWords = [];
+      const getRandomWords = (topicName) => {
+        const topic = Topics.find((t) => t.name === topicName);
+        if (!topic) throw new Error(`Topic ${topicName} not found`);
+
+        const shuffleWords = [...topic.words].sort(() => Math.random() - 0.5);
+        return shuffleWords;
+      };
+      gameState.totalWords = getRandomWords(gameState.topic);
       // Firebase의 gameStatus를 'playing'으로 업데이트
       try {
         const roomRef = db.collection('GameRooms').doc(roomId);
@@ -227,17 +234,6 @@ io.on('connection', (socket) => {
     if (!gameState) {
       console.error(`Room ${roomId} not found`);
       return;
-    }
-
-    if (gameState.totalWords.length < 1) {
-      const getRandomWords = (topicName) => {
-        const topic = Topics.find((t) => t.name === topicName);
-        if (!topic) throw new Error(`Topic ${topicName} not found`);
-
-        const shuffleWords = [...topic.words].sort(() => Math.random() - 0.5);
-        return shuffleWords;
-      };
-      gameState.totalWords = getRandomWords(gameState.topic);
     }
 
     gameState.gameStatus = 'choosing';


### PR DESCRIPTION
### 📝 관련 이슈
closed #12 

### ✨ 반영 브랜치
<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->
- FROM: `12-feat/game-flow-socket`
- TO: `master`

### ✅ PR 내용
<!-- 기능마다 아래 템플릿으로 PR에 대한 설명을 적어주세요 (기능별 AS-IS, TO-BE, 변경이유 등) -->
- [x] 게임 시작 로직과 초기화
> - AS-IS : `startGame` 이벤트가 발생하면 간단하게 게임 상태가 'choosing'으로 전환되며, 초기 출제자가 방장으로 설정
> - TO-BE : `startGame` 이벤트 시 `gameRooms[roomId]` 상태의 `round`와 `turn`을 초기화하며, `selectedWords`를 단어 리스트에서 랜덤하게 두 개 선택하여 출제자가 선택할 수 있도록 설정. 이후 `gameStatus`를 'choosing'으로 변경하고 `selectionDeadline`을 설정하여 출제자가 단어를 고르지 않으면 자동으로 다음 턴으로 넘어가도록 추가 로직을 작성
> - Description : 게임 시작 시 방장이 아닌 참가자에게는 출제자가 단어를 선택할 때 대기 화면이 보여지도록 하고, 일정 시간 내에 단어 선택이 이루어지지 않으면 자동으로 `timeOver` 상태로 전환하여 다음 출제자가 설정되도록 하였습니다.

- [x] 게임 종료 조건 추가
> - AS-IS : 게임 종료 조건이 없는 상태이며, 기본적으로 모든 참가자가 단어 선택이 이루어지면 자동으로 진행.
> - TO-BE : 현재 라운드가 `maxRound`보다 클 경우 게임을 `waiting` 상태로 설정하고, `gameRooms` 상태를 초기화. 이후 `Firebase`의 `gameStatus`도 함께 업데이트하여 모든 참가자에게 종료 상태를 알
> - Description : 게임이 `maxRound`에 도달하면 자동으로 종료되어 `waiting` 상태로 전환되며, 게임을 다시 시작하기 위해선 호스트의 시작 입력이 필요합니다. 이를 통해 게임이 명확한 종료 조건을 가지며, 모든 참가자가 일관된 게임 종료 상태를 확인할 수 있습니다.

- [x] Firebase DB 상태 업데이트
> - AS-IS : 없음
> - TO-BE : 게임 시작 및 게임이 종료 조건을 만족하거나, 참가자 수가 부족할 경우 자동으로 Firebase의 gameStatus를 `playing`, `waiting`으로 업데이트하여 게임이 진행중, 종료 상태임을 서버와 모든 참가자에게 알림.
> - Description : 시작 조건, 종료 조건을 만족할 시 게임을 시작하며 종료하고, Firebase와 동기화하여 다음 게임을 준비하는 상태로 전환합니다.

- [x] 출제자 설정과 다음 턴으로의 전환 로직
> - AS-IS : 게임에서 현재 턴이 종료되면 단순히 다음 출제자로 넘어가도록 설정된 기본 로직만 존재
> - TO-BE : `gameRooms[roomId].order` 에 따라 출제자를 순서대로 설정하며, 모든 참가자에게 동일하게 `gameStateUpdate` 이벤트를 통해 상태를 전달. 턴이 끝나면 현재 출제자의 종료 시점을 `turnDeadline`으로 설정하고, 이를 기반으로 다음 출제자가 선택될 수 있도록 수정
> - Description : 출제자가 단어를 고르지 않으면 자동으로 `timeOver` 상태로 전환 후 다음 출제자로 넘어가는 로직이 추가하였고, 모든 참가자가 동기화된 상태를 유지할 수 있도록 하였습니다.

- [x] 새로운 출제자가 할당될 때 캔버스 초기화
> - AS-IS : 출제자가 변경될 때 캔버스 초기화가 되지 않아 이전 그리기가 남아 있을 수 있음.
> - TO-BE : `proceedToNextDrawer` 호출 시 새로운 출제자가 할당될 때 `clearCanvas` 이벤트를 실행하여 캔버스를 초기화. 각 라운드마다 캔버스가 초기 상태로 돌아가며, 출제자가 바뀌면 자동으로 이전 그림을 지워줌.
> - Description : 출제자가 바뀔 때마다 `clearCanvas` 이벤트를 통해 캔버스를 초기화함으로써, 참가자들의 시각적 혼란을 방지하는 효과가 있습니다.

- [x] 단어 리스트 관리와 주제 기반 랜덤 단어 생성
> - AS-IS : 기존 룸이 생성될 때만 랜덤 단어가 totalWords에 업데이트
> - TO-BE : 게임 종료 시 랜덤 단어를 다시 totalWords에 업데이트
> - Description : 게임 종료 후 게임을 재시작 할 때 랜덤 단어가 아닌 기존 단어로 게임이 시작됨을 방지하기 위해 게임 종료 시 다시 한번 더 단어들을 랜덤으로 totalWords에 업데이트 로직 추가했습니다.

- [x] 사용자 연결 해제 시 다음 출제자 설정 및 남은 참가자 수 체크
> - AS-IS : 게임 참가자가 나가면 해당 참가자의 상태만 삭제되며, 추가적인 로직이 구현되지 않음
> - TO-BE : 현재 출제자(currentDrawer)가 나가면 `proceedToNextDrawer` 함수로 다음 출제자가 자동으로 할당되며, 남은 참가자 수가 3명 미만이면 `waiting` 상태로 게임을 중단. 만약 방장이 나가면 방의 첫 번째 참가자를 새로운 방장으로 지정
> - Description : 참가자 수가 부족할 경우 자동으로 대기 상태로 전환되며, 현재 출제자가 나갈 때 새로운 출제자가 즉시 할당되는 로직이 추가되어 게임이 중단되지 않고 연속성을 유지할 수 있도록 합니다.

### 🌐 테스트 배포

- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
  > - 테스트 배포 주소: https://jm-doodleplay.netlify.app/game
  > - 테스트 환경 (OS): Windows
  > - 테스트 환경 (Browser): Chrome / Firefox / Edge

### 📌 ETC
위 내용이 부실해서 설명이 부족할 수 있습니다. 궁금하신점은 리뷰에 남겨주시면 성실히 답변드리겠습니다!
아쉽게도 Server merge 되지 않아서 확인은 어렵습니다. 참고 바랍니다.
코드 위주의 리뷰 부탁드립니다!
