### PR TITLE
[FIX] totalWords 업데이트 시점 변경 #14

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -146,7 +146,6 @@ io.on('connection', (socket) => {
       gameState.gameStatus = 'waiting';
       gameState.selectionDeadline = null;
       gameState.turnDeadline = null;
-      gameState.totalWords = getRandomWords(gameState.topic);
 
       // Firebase의 gameStatus를 'waiting'으로 업데이트
       try {
@@ -239,6 +238,7 @@ io.on('connection', (socket) => {
     gameState.currentDrawer = gameState.host;
     gameState.round = 1;
     gameState.turn = 1;
+    gameState.totalWords = getRandomWords(gameState.topic);
 
     gameState.selectedWords = gameState.totalWords.slice(0, 2);
     gameState.selectionDeadline = Date.now() + 5000;


### PR DESCRIPTION
### 📝 관련 이슈
closed #14 

### ✨ 반영 브랜치
<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->
- FROM: `14-fix/totalwords-update-timing`
- TO: `master`

### ✅ PR 내용
<!-- 기능마다 아래 템플릿으로 PR에 대한 설명을 적어주세요 (기능별 AS-IS, TO-BE, 변경이유 등) -->
- [x] totalWords 업데이트 시점 변경
> - AS-IS : totalWords 단어들을 랜덤하게 업데이트 하는 시점이 게임 종료 할 때 였음.
> - TO-BE: totalWords 단어들을 랜덤하게 업데이트 하는 시점을 게임 스타트 버튼을 눌렀을 때로 변경
> - Description : 종료되는 로직이 maxRound를 넘어가면 종료되도록 구현했기에, 비정상 적인 게임 종료가 되면 해당 `totalWords` 배열을 그대로 다시 사용하게 되는 상황이 생깁니다. 해당 시점을 변경함으로써 게임을 재시작 할 때 발생하는 문제가 없도록 변경했습니다.

