### PR TITLE
[FIX] 게임 진행 버그 수정 작업 #18

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -569,6 +569,7 @@ io.on('connection', socket => {
       // 남은 플레이어 수가 3명 미만이면 게임을 대기 상태로 전환
       if (gameState.order.length <= 2) {
         await finishedGame(roomId);
+        io.to(roomId).emit('gameStateUpdate', gameState);
         return;
       }
 

--- a/src/server.js
+++ b/src/server.js
@@ -115,6 +115,27 @@ io.on('connection', socket => {
     socket.to(roomId).emit('drawingData', drawingData); // 같은 방에 있는 다른 사용자에게 브로드캐스트
   });
 
+  const finishedGame = async roomId => {
+    const gameState = gameRooms[roomId];
+    if (!gameState || gameState.gameStatus === 'gameOver') return;
+
+    gameState.gameStatus = 'gameOver';
+    gameState.selectionDeadline = null;
+    gameState.turnDeadline = null;
+
+    // Firebase의 gameStatus를 'waiting'으로 업데이트
+    try {
+      const roomRef = db.collection('GameRooms').doc(roomId);
+      await roomRef.update({ gameStatus: 'waiting' });
+    } catch (error) {
+      console.error(
+        `Failed to update gameStatus in Firebase for room ${roomId}:`,
+        error
+      );
+    }
+    io.to(roomId).emit('gameStateUpdate', gameState);
+  };
+
   // 게임 진행 함수 현재 turnDeadline이 되면 다음 턴이 되도록 구현되어 있음. 정답 처리 추가 부분
   const nextTurn = roomId => {
     const gameState = gameRooms[roomId];
@@ -146,7 +167,7 @@ io.on('connection', socket => {
   };
 
   // 다음 Drawer로 진행하고 초기화 설정
-  const proceedToNextDrawer = async roomId => {
+  const proceedToNextDrawer = roomId => {
     const gameState = gameRooms[roomId];
     if (!gameState) return;
 
@@ -160,7 +181,10 @@ io.on('connection', socket => {
     };
 
     // 턴을 조정해 참여자 수를 넘지 않도록 하고, 턴이 참여자 수와 같으면 라운드를 증가
-    if (gameState.turn >= gameState.order.length) {
+    if (
+      gameState.turn >= gameState.order.length &&
+      gameState.gameStatus !== 'gameOver'
+    ) {
       gameState.turn = 1;
       gameState.round += 1;
       io.to(roomId).emit('roundProcess', {
@@ -174,79 +198,70 @@ io.on('connection', socket => {
 
     // 게임 종료 조건 확인: 라운드가 maxRound보다 크거나 같으면 게임 종료
     if (gameState.round > gameState.maxRound) {
-      gameState.gameStatus = 'waiting';
-      gameState.selectionDeadline = null;
-      gameState.turnDeadline = null;
-
-      // Firebase의 gameStatus를 'waiting'으로 업데이트
-      try {
-        const roomRef = db.collection('GameRooms').doc(roomId);
-        await roomRef.update({ gameStatus: 'waiting' });
-      } catch (error) {
-        console.error(
-          `Failed to update gameStatus in Firebase for room ${roomId}:`,
-          error
-        );
-      }
-
-      io.to(roomId).emit('gameStateUpdate', gameState);
+      finishedGame(roomId);
       return;
     }
+    if (gameState.gameStatus !== 'gameOver') {
+      // currentDrawer를 현재 turn에 맞춰 할당
+      const nextDrawerIndex = gameState.turn - 1;
+      gameState.currentDrawer = gameState.order[nextDrawerIndex];
 
-    // currentDrawer를 현재 turn에 맞춰 할당
-    const nextDrawerIndex = gameState.turn - 1;
-    gameState.currentDrawer = gameState.order[nextDrawerIndex];
+      wordWave += 1;
+      gameState.gameStatus = 'choosing';
+      gameState.currentWord = null;
+      gameState.isWordSelected = false;
+      gameState.selectedWords = gameState.totalWords.slice(
+        (wordWave - 1) * 2,
+        wordWave * 2
+      );
+      gameState.selectionDeadline = Date.now() + 5000;
+      gameState.turnDeadline = null;
+      gameState.correctAnswerCount = 0;
+      gameState.correctAnsweredUser = [];
 
-    wordWave += 1;
-    gameState.gameStatus = 'choosing';
-    gameState.currentWord = null;
-    gameState.isWordSelected = false;
-    gameState.selectedWords = gameState.totalWords.slice(
-      (wordWave - 1) * 2,
-      wordWave * 2
-    );
-    gameState.selectionDeadline = Date.now() + 5000;
-    gameState.turnDeadline = null;
-    gameState.correctAnswerCount = 0;
-    gameState.correctAnsweredUser = [];
+      io.to(roomId).emit('clearCanvas');
 
-    io.to(roomId).emit('clearCanvas');
+      setTimeout(() => {
+        if (
+          !gameState.isWordSelected &&
+          Date.now() >= gameState.selectionDeadline
+        ) {
+          // 단어가 선택되지 않은 경우, TimeOver 상태로 전환
+          if (gameState.gameStatus !== 'gameOver') {
+            gameState.gameStatus = 'timeOver';
+          }
 
-    setTimeout(() => {
-      if (
-        !gameState.isWordSelected &&
-        Date.now() >= gameState.selectionDeadline
-      ) {
-        // 단어가 선택되지 않은 경우, TimeOver 상태로 전환
-        gameState.gameStatus = 'timeOver';
-        io.to(roomId).emit('gameStateUpdate', gameState);
-
-        // 3초 후에 다음 턴으로 전환
-        setTimeout(() => {
-          proceedToNextDrawer(roomId);
           io.to(roomId).emit('gameStateUpdate', gameState);
-        }, 3000);
-      }
-    }, 5000);
 
+          // 3초 후에 다음 턴으로 전환
+          setTimeout(() => {
+            proceedToNextDrawer(roomId);
+            io.to(roomId).emit('gameStateUpdate', gameState);
+          }, 3000);
+        }
+      }, 5000);
+    }
     io.to(roomId).emit('gameStateUpdate', gameState);
   };
 
   // 선택 후 턴 시작 및 turnDeadline 설정
   const startTurn = roomId => {
     const gameState = gameRooms[roomId];
-    if (!gameState || gameState.gameStatus === 'waiting') return;
+    if (
+      !gameState ||
+      gameState.gameStatus === 'waiting' ||
+      gameState.gameStatus === 'gameOver'
+    )
+      return;
     // 턴 시작 시 초기화: 단어 선택 상태 및 현재 단어 초기화
 
     if (gameState.isWordSelected) {
       gameState.gameStatus = 'drawing';
       gameState.turnDeadline = Date.now() + 90000;
       io.to(roomId).emit('gameStateUpdate', gameState);
-    } else if (
-      Date.now() >= gameState.selectionDeadline &&
-      gameState.gameStatus !== 'waiting'
-    ) {
+    } else if (Date.now() >= gameState.selectionDeadline) {
       // 선택 시간이 지나면 timeOver 상태로 전환 후 다음 턴 진행
+
       gameState.gameStatus = 'timeOver';
       io.to(roomId).emit('gameStateUpdate', gameState);
 
@@ -305,7 +320,8 @@ io.on('connection', socket => {
       if (
         gameState &&
         gameState.turnDeadline &&
-        gameState.gameStatus !== 'waiting'
+        gameState.gameStatus !== 'waiting' &&
+        gameState.gameStatus !== 'gameOver'
       ) {
         nextTurn(roomId);
       }
@@ -387,6 +403,7 @@ io.on('connection', socket => {
 
     //정답과 비슷한 채팅을 쳤을 때
     if (
+      gameState.gameStatus === 'drawing' && // DH bug
       !gameState.correctAnsweredUser.includes(socket.id) &&
       !gameState.currentDrawer.includes(socket.id) &&
       message !== gameState.currentWord &&
@@ -406,8 +423,10 @@ io.on('connection', socket => {
       message.includes(gameState.currentWord)
     ) {
       if (
-        gameState.correctAnsweredUser.includes(socket.id) ||
-        gameState.currentDrawer.includes(socket.id)
+        (gameState.gameStatus === 'drawing' && // DH bug
+          gameState.correctAnsweredUser.includes(socket.id)) ||
+        (gameState.gameStatus === 'drawing' && // DH bug
+          gameState.currentDrawer.includes(socket.id))
       ) {
         socket.emit('cheating', {
           nickname,
@@ -476,7 +495,10 @@ io.on('connection', socket => {
     }
 
     //모든 유저가 정답을 맞추면 다음턴으로 진행
-    if (gameState.correctAnswerCount === gameState.order.length - 1) {
+    if (
+      gameState.correctAnswerCount === gameState.order.length - 1 &&
+      gameState.gameStatus === 'drawing' // DH bug
+    ) {
       gameState.participants[gameState.currentDrawer].score += 8; //전원 정답이므로 출제자 8점
       io.to(roomId).emit(
         'playDrawerScoreAnimation',
@@ -546,8 +568,14 @@ io.on('connection', socket => {
         const remainingUsers = gameState.order;
         if (remainingUsers.length > 0) {
           gameState.host = remainingUsers[0];
-          console.log(`New host assigned: ${gameState.host}`);
+          io.to(roomId).emit('gameStateUpdate', gameState);
         }
+      }
+
+      // 남은 플레이어 수가 3명 미만이면 게임을 대기 상태로 전환\
+      if (gameState.order.length <= 2) {
+        await finishedGame(roomId);
+        return;
       }
 
       // 현재 그림을 그리는 출제자가 나가면 다음 순서로 지정
@@ -566,11 +594,13 @@ io.on('connection', socket => {
         gameState.selectionDeadline = Date.now() + 5000;
         gameState.turnDeadline = null;
         io.to(roomId).emit('clearCanvas');
+        io.to(roomId).emit('gameStateUpdate', gameState);
+
         setTimeout(() => {
           if (
+            gameState.gameStatus !== 'gameOver' &&
             !gameState.isWordSelected &&
-            Date.now() >= gameState.selectionDeadline &&
-            gameState.gameStatus !== 'waiting'
+            Date.now() >= gameState.selectionDeadline
           ) {
             // 단어가 선택되지 않은 경우, TimeOver 상태로 전환
             gameState.gameStatus = 'timeOver';
@@ -578,32 +608,12 @@ io.on('connection', socket => {
 
             // 3초 후에 다음 턴으로 전환
             setTimeout(() => {
-              proceedToNextDrawer(roomId);
-              io.to(roomId).emit('gameStateUpdate', gameState);
+              if (gameState.gameStatus !== 'gameOver') {
+                proceedToNextDrawer(roomId);
+              }
             }, 3000);
           }
         }, 5000);
-      }
-
-      // 남은 플레이어 수가 3명 미만이면 게임을 대기 상태로 전환
-      const playerCount = Object.keys(gameState.participants).length;
-      if (playerCount < 3) {
-        gameState.gameStatus = 'waiting';
-        gameState.selectionDeadline = null;
-        gameState.turnDeadline = null;
-
-        io.to(roomId).emit('gameStateUpdate', gameState);
-
-        // Firebase의 gameStatus를 업데이트
-        try {
-          const roomRef = db.collection('GameRooms').doc(roomId);
-          await roomRef.update({ gameStatus: 'waiting' });
-        } catch (error) {
-          console.error(
-            `Failed to update gameStatus in Firebase for room ${roomId}:`,
-            error
-          );
-        }
       }
     });
   });


### PR DESCRIPTION
### 📝 관련 이슈
closed #18 

### ✨ 반영 브랜치
<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->
- FROM: `18-fix/game-flow-bug-fix`
- TO: `master`

### ✅ PR 내용
<!-- 기능마다 아래 템플릿으로 PR에 대한 설명을 적어주세요 (기능별 AS-IS, TO-BE, 변경이유 등) -->
- [x] 게임 종료 상태 추가
> - AS-IS: 게임 시작 후 출제자가 단어 선택 단계에서 게임을 퇴장하면 게임이 종료(status: waiting) 됐다가 일정 시간 후 time's up 뜨면서 다시 게임이 계속 진행됨.
> - TO-BE: 확실한 게임 종료 상태 추가로 상태가 게임 종료 상태면, 게임 더 이상 진행 불가.
> - Description: `gameState.gameStatus` = 'gameOver' 추가로 정확한 게임 종료 상태 추가 

- [x] 단어 선택 화면 버그
> - AS-IS: 출제자가 choosing 단계에서 나가게 되면 다음 턴 받은 사람의 choosing의 comment가 2개가 됨.
> - TO-BE: 일반 진행과 같은 화면 출력.
> - Description: 기존 순서 턴의 사람이 이어 받아 자연스럽게 게임 진행

### 📌 ETC
<!-- 레퍼런스, 참고할 사항, 질문 사항이 있다면 적어주세요 (Optional) -->
merge 후 확인 가능하여 코드 위주로 확인 부탁드립니다.
