### PR TITLE
[FIX] 게임 진행 버그 수정 #23

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -285,6 +285,8 @@ io.on('connection', socket => {
     gameState.currentDrawer = gameState.host;
     gameState.round = 1;
     gameState.turn = 1;
+    gameState.currentWord = null;
+    gameState.isWordSelected = false;
     gameState.totalWords = getRandomWords(gameState.topic);
 
     // 모든 참가자의 점수를 0으로 초기화


### PR DESCRIPTION
### 📝 관련 이슈
closed #23 

### ✨ 반영 브랜치
<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->
- FROM: `23-fix/game-flow-bug-fix`
- TO: `master`

### ✅ PR 내용
<!-- 기능마다 아래 템플릿으로 PR에 대한 설명을 적어주세요 (기능별 AS-IS, TO-BE, 변경이유 등) -->
- [x] 게임 끝난 후 다시 start 눌러서 시작하면 이전에 선택한 단어가 초기화되지 않음
> - AS-IS: 첫 게임 끝난 후 다시 start 눌러서 시작하면 기존 마지막으로 선택한 단어가 초기화되지 않아서 다음 게임 시작 후 selectWord를 선택하지 않아도 기존 currentWord로 게임이 진행되는 버그
> - TO-BE: 게임 시작 버튼 클릭 시 currentWord를 빈 값으로 업데이트하여 게임 진행


### 📌 ETC
<!-- 레퍼런스, 참고할 사항, 질문 사항이 있다면 적어주세요 (Optional) -->
말씀하셨던 time's up 버그 조건을 아직 발견하지 못해서 문제가 발생 시 바로 수정하도록 하겠습니다!