### PR TITLE
[FIX] 단어 선택 시 채팅 오류 수정

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -447,10 +447,7 @@ io.on('connection', socket => {
     console.log(`${nickname} sent message in room ${roomId}: ${message}`);
 
     //waiting 상태 일 경우 조건과 상관없이 메세지를 전송
-    if (
-      gameState.gameStatus === 'waiting' ||
-      gameState.gameStatus === 'gameOver'
-    ) {
+    if (gameState.gameStatus !== 'drawing') {
       io.to(roomId).emit('newMessage', {
         nickname,
         message,

--- a/src/server.js
+++ b/src/server.js
@@ -446,7 +446,7 @@ io.on('connection', socket => {
     const { nickname, message } = messageData;
     console.log(`${nickname} sent message in room ${roomId}: ${message}`);
 
-    //waiting 상태 일 경우 조건과 상관없이 메세지를 전송
+    //drawing 상태가 아닐 경우 조건과 상관없이 메세지를 전송
     if (gameState.gameStatus !== 'drawing') {
       io.to(roomId).emit('newMessage', {
         nickname,


### PR DESCRIPTION
### 📝 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #31 
### ✨ 반영 브랜치
<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->
- FROM: `31-fix/chat-error`
- TO: `main`

### ✅ PR 내용
<!-- 기능마다 아래 템플릿으로 PR에 대한 설명을 적어주세요 (기능별 AS-IS, TO-BE, 변경이유 등) -->
- [x] 채팅 오류 수정
> - Description:  채팅을 입력했을 때 gameStatus에 따라서 정답 여부를 판단하는 로직를 거치는데 'drawing' 단계가 
아닐 경우에는 currentWord가 null 인 경우와 같은 여러 TypeError가 발생하여 소켓 연결이 끊어지는 오류가 있었습니다. 
때문에 drawing 단계가 아니라면 정답 여부를 판단하지 않고 메세지가 전송되도록 조건문을 수정했습니다.
  ```ts
      //waiting 상태 일 경우 조건과 상관없이 메세지를 전송
    if (
      gameState.gameStatus === 'waiting' ||
      gameState.gameStatus === 'gameOver'
    ) 
  ``` 
위 조건문을 아래와 같이 수정
  ```ts
      //drawing 상태가 아닐 경우 조건과 상관없이 메세지를 전송
    if (gameState.gameStatus !== 'drawing')
  ```

### 📸 스크린샷
<!-- 가능하다면 스크린샷을 첨부해주세요 (Optional) -->

### 📌 ETC
<!-- 레퍼런스, 참고할 사항, 질문 사항이 있다면 적어주세요 (Optional) -->
